### PR TITLE
Fix Weibull Hazards, Case Insensitive Distributions

### DIFF
--- a/R/flexsurvreg.R
+++ b/R/flexsurvreg.R
@@ -433,6 +433,12 @@ flexsurvreg <- function(formula, anc=NULL, data, weights, bhazard, subset, na.ac
     if (missing(dist)) stop("Distribution \"dist\" not specified")
     if (is.character(dist)) {
         match.arg(dist, names(flexsurv.dists))
+        # Added: case insensitve matching of distributions
+        # Step 1: Use match.arg on lowercase argument, dists.
+        # Step 2: Use match to get index in distribution list from
+        # value obtained in step 1, and grab corresponding element.
+        dist <- match.arg(tolower(dist), tolower(names(flexsurv.dists)))
+        dist <- names(flexsurv.dists)[match(dist,tolower(names(flexsurv.dists)))]
         dlist <- flexsurv.dists[[dist]]
     }
     else if (is.list(dist)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -274,6 +274,11 @@ pweibull.quiet <- function(q, shape, scale = 1, lower.tail = TRUE, log.p = FALSE
     ret
 }
 
+hweibull.quiet <- function(x, shape, scale = 1, log = FALSE) {
+  ret <- suppressWarnings(hweibull(x=x, shape=shape, scale=scale, log=log))
+  ret
+}
+
 rweibull.quiet <- rweibull
 
 ## suppresses NOTE from checker about variables created with "assign"

--- a/tests/testthat/test_flexsurvreg.R
+++ b/tests/testthat/test_flexsurvreg.R
@@ -421,3 +421,15 @@ test_that("warning with strata", {
     expect_warning(flexsurvreg(formula = Surv(ovarian$futime, ovarian$fustat) ~ strata(ovarian$resid.ds), dist="gengamma", inits=c(6,1,-1,0)),
                    "Ignoring \"strata\" function: interpreting \"ovarian\\$resid.ds\" as a covariate on \"mu\"")
 })
+
+test_that("Distribution names are case insensitive",{
+  fs1 = flexsurvreg(Surv(rectime, censrec)~group,dist="weibull",data=bc)
+  fs2 = flexsurvreg(Surv(rectime, censrec)~group,dist="Weibull",data=bc)
+ expect_equal(fs1$loglik, fs2$loglik, tol=1e-06)
+})
+
+test_that("Weibull hazards from summary are reliable",{
+  fs1 = flexsurvreg(Surv(rectime, censrec)~group ,dist="weibull",data=bc)
+  output = summary(fs1, t=seq(from=0,to=30000,length.out=100), ci=F, tidy=T)
+  expect_true(all(is.finite(output$est)))
+})


### PR DESCRIPTION
Makes following changes:
-Defines missing hweibull.quiet to avoid apparent numerical instability which was occuring w/ AFT Weibull hazards.
-Changes matching of distribution argument to be case insensitive because Gompertz and Weibull are proper nouns and it pains me to not capitalize them...
-Added tests for changes above.