### PR TITLE
Gompertz functions to respect asymptote when shape < 0 and infinite q

### DIFF
--- a/src/gompertz.cpp
+++ b/src/gompertz.cpp
@@ -23,8 +23,12 @@ namespace {
 	const double scale_q = shape * q;
 	return - rate * q * exprel(scale_q);
       } else {
-	// q is infinite (and positive)
-	return R_NegInf;
+        // If shape is negative, Gompertz reaches asymptote > 0
+        if (shape < 0) {
+          return shape / rate;
+        } else {
+          return R_NegInf;
+        }
       }
     }
     

--- a/src/gompertz.cpp
+++ b/src/gompertz.cpp
@@ -25,7 +25,7 @@ namespace {
       } else {
         // If shape is negative, Gompertz reaches asymptote > 0
         if (shape < 0) {
-          return shape / rate;
+          return rate / shape;
         } else {
           return R_NegInf;
         }

--- a/tests/testthat/test_gompertz.R
+++ b/tests/testthat/test_gompertz.R
@@ -41,7 +41,7 @@ test_that("Gompertz with chance of living forever",{
     x <- c(0.8, 0.9, 0.97, 0.99)
     expect_equal(qgompertz(x, shape=shape, rate=rate), c(1.28150707286845, 2.4316450975351, Inf, Inf))
                                         # qgeneric(pgompertz, p=x, shape=shape, rate=rate) # won't work - needs smoothness
-    expect_equal(pgompertz(Inf, shape=shape, rate=rate), 1)
+    expect_equal(pgompertz(Inf, shape=shape, rate=rate), 0.2834687)
 })
 
 test_that("Gompertz hazards",{

--- a/tests/testthat/test_gompertz.R
+++ b/tests/testthat/test_gompertz.R
@@ -41,7 +41,11 @@ test_that("Gompertz with chance of living forever",{
     x <- c(0.8, 0.9, 0.97, 0.99)
     expect_equal(qgompertz(x, shape=shape, rate=rate), c(1.28150707286845, 2.4316450975351, Inf, Inf))
                                         # qgeneric(pgompertz, p=x, shape=shape, rate=rate) # won't work - needs smoothness
-    expect_equal(pgompertz(Inf, shape=shape, rate=rate), 0.2834687)
+    expect_equal(pgompertz(Inf, shape=shape, rate=rate, lower.tail = F), exp(rate/shape))
+    expect_equal(
+      pgompertz(Inf, shape=shape, rate=rate, lower.tail = F),
+      pgompertz(9999999, shape=shape, rate=rate, lower.tail = F)
+    )
 })
 
 test_that("Gompertz hazards",{


### PR DESCRIPTION
This resolves #34 by changing the behavior of gompertz functions to return values consistent with the asymptote when q = Inf.