### PR TITLE
Fix to rmst_generic in case length(t)>1 and length(start)=1

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -121,6 +121,7 @@ rmst_generic <- function(pdist, t, start=0, matargs=NULL, ...)
 {
   args <- list(...)
   t_len <- length(t)
+  if(length(start) == 1) start <- rep(start, length(t))
   ret <- numeric(t_len)
   start_p = 1 - pdist(start,...)
   for(i in seq_len(t_len)){


### PR DESCRIPTION
Fixes #36 by recycling start if `length(start) == 1`.