### PR TITLE
Add indexing to loop through a supplied newdata dataframe for models …

### DIFF
--- a/R/mstate.R
+++ b/R/mstate.R
@@ -258,7 +258,13 @@ pars.fmsm <- function(x, trans, newdata=NULL, tvar="trans")
         if (ntr != length(na.omit(as.vector(trans)))) stop(sprintf("x is a list of %s flexsurvreg objects, but trans indicates %s transitions", ntr, length(na.omit(as.vector(trans)))))
         basepar <- matrix(nrow=ntr, ncol=length(x[[1]]$dlist$pars), dimnames=list(NULL,x[[1]]$dlist$pars))
         for (i in 1:ntr){
-            X <- if (x[[i]]$ncovs==0) matrix(0) else form.model.matrix(x[[i]], as.data.frame(newdata))
+           X <- if (x[[i]]$ncovs==0) matrix(0) else {
+              if(nrow(newdata) == 1L) {
+                 X <- form.model.matrix(x[[i]], as.data.frame(newdata))
+              } else if(nrow(newdata) == ntr){
+                 X <- form.model.matrix(x[[i]], as.data.frame(newdata[i, ,drop = FALSE]))
+              } else stop("Newdata must have one row, or one row per allowed transition")
+              }
             beta <- if (x[[i]]$ncovs==0) 0 else x[[i]]$res.t[x[[i]]$covpars,"est"]
             basepar[i,] <- add.covs(x[[i]], x[[i]]$res.t[x[[i]]$dlist$pars,"est"], beta, X, transform=FALSE)
         }


### PR DESCRIPTION
…supplied as a list

Hello,
When using pmatrix.fs I found that I could not supply different covariate values inside newdata when I had supplied the models as  a list. It worked fine when the transitions were modelled in a single model.
It was very trivial to modify this by adding a change to pars.fmsm, and I have made these changes on a fork of your repo.
I have done some experimenting and it doesn't seem to break anything.
I didn't see anywhere what your feelings were about pull requests. Please feel free to reject this!!!
best wishes,
David
