### PR TITLE
Account for case weights in survival and cumulative hazard KM plots

### DIFF
--- a/R/plot.flexsurvreg.R
+++ b/R/plot.flexsurvreg.R
@@ -111,10 +111,10 @@ plot.flexsurvreg <- function(x, newdata=NULL, X=NULL, type="survival", fn=NULL, 
         ## If any continuous covariates, it is hard to define subgroups
         ## so just plot the population survival
         if (type=="survival") {
-            plot(survfit(form, data=mm), col=col.obs, lty=lty.obs, lwd=lwd.obs, ylim=ylim, ...)
+            plot(survfit(form, data=mm, weights=dat$m$`(weights)`), col=col.obs, lty=lty.obs, lwd=lwd.obs, ylim=ylim, ...)
         }
         else if (type=="cumhaz") {
-            plot(survfit(form, data=mm), fun="cumhaz", col=col.obs, lty=lty.obs, lwd=lwd.obs, ylim=ylim, ...)
+            plot(survfit(form, data=mm, weights=dat$m$`(weights)`), fun="cumhaz", col=col.obs, lty=lty.obs, lwd=lwd.obs, ylim=ylim, ...)
         }
         else if (type=="hazard") {
             muhaz.args <- list(...)[names(list(...)) %in% names(formals(muhaz))]


### PR DESCRIPTION
The Kaplan Meier produced by `plot.flexsurvreg` do not account for case weights. While this issue can be easily worked around, the plots can be misleading as all cases are associated to unit weights, and weighted KM are expected by users.

As all `flexsurvreg` objects include case weights in ``$data$m$`(weights)` `` this can be added easily to the ``type == "survival"`` and ``type == "cumhaz"`` options in `plot.flexsurvreg`. The `muhaz` function used in ``type == "hazard"`` does not have a built-in functionality accounting for case weights, and is not modified in this pull request.