### PR TITLE
Fix qgeneric without args

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -209,7 +209,7 @@ qgeneric <- function(pdist, p, matargs=NULL, scalarargs=NULL, ...)
     ## Other args assumed to contain vectorisable parameters of the distribution.
     ## Replicate all to their maximum length, along with p
     matlen <- if(is.null(matargs)) NULL else sapply(args.mat, function(x){if(is.matrix(x))nrow(x) else 1})
-    veclen <- if (is.null(args)) NULL else sapply(args, length)
+    veclen <- if (length(args) == 0) NULL else sapply(args, length)
     maxlen <- max(c(length(p), veclen, matlen))
     for (i in seq(along=args))
         args[[i]] <- rep(args[[i]], length.out=maxlen)


### PR DESCRIPTION
If no args are passed, or if all args are included in `matargs` and/or `scalarargs`, `qgeneric` raises an error. For example, it is not possible to calculate the median of the standard normal distribution (without explicitly supplying the mean and sd):

```
> qgeneric(pnorm, .5)
Error in max(c(length(p), veclen, matlen)) : 
  invalid 'type' (list) of argument
```