### PR TITLE
Improve dbase.survspline performance

### DIFF
--- a/R/spline.R
+++ b/R/spline.R
@@ -99,8 +99,10 @@ dbase.survspline <- function(q, gamma, knots, scale, offset=0, deriv=FALSE){
     q <- rep(q, length=nret)
     offset <- rep(offset, length=nret)
 
-    gamma <- do.call("rbind", rep(list(gamma), nret))
-    knots <- do.call("rbind", rep(list(knots), nret))
+    gamma <- matrix(rep(as.numeric(t(gamma)), length.out = ncol(gamma) * nret),
+                    ncol = ncol(gamma), byrow = TRUE)
+    knots <- matrix(rep(as.numeric(t(knots)), length.out = ncol(knots) * nret),
+                    ncol = ncol(knots), byrow = TRUE)
 
     if (ncol(gamma) != ncol(knots)) {
         stop("length of gamma should equal number of knots")


### PR DESCRIPTION
Calculating the CI of e.g. the median of a `flexsurvpline` model takes quite some time.

```r
library(flexsurv)
spl <- flexsurvspline(Surv(recyrs, censrec) ~ group, data = bc, k = 1, scale = "odds")
system.time(summary(spl, type = "median"))
```

This takes around 11 seconds on my system.

```
   user  system elapsed 
  11.01    0.01   11.04
```

This PR improves the performance of the matrix replications in `dbase.survspline` (based on https://stackoverflow.com/a/13035504), after which the `summary` call takes around 7 seconds.

```
   user  system elapsed 
   7.16    0.00    7.15
```
