### PR TITLE
Clean up predict and broom functions and expand test coverage

### DIFF
--- a/R/broom-funs.R
+++ b/R/broom-funs.R
@@ -217,20 +217,15 @@ augment.flexsurvreg <- function(x, data = NULL, newdata = NULL,
   if (is.null(newdata)) {
     preds <- predict(x, type = type.predict, se.fit = TRUE)
     res <- tibble::as_tibble(data)
-    res <- tibble::add_column(
-      .data = res,
-      .fitted = preds$.pred,
-      .se.fit = preds$.std_error,
+    res <- dplyr::bind_cols(
+      res,
+      preds,
       .resid = residuals(x, type = type.residuals)
     )
   } else {
     preds <- predict(x, type = type.predict, se.fit = TRUE, newdata = newdata)
     res <- tibble::as_tibble(newdata)
-    res <- tibble::add_column(
-      .data = res,
-      .fitted = preds$.pred,
-      .se.fit = preds$.std_error
-    )
+    res <- dplyr::bind_cols(res, preds)
   }
   res
 }

--- a/R/predict.flexsurvreg.R
+++ b/R/predict.flexsurvreg.R
@@ -14,15 +14,16 @@
 #'   If \code{newdata} is omitted, then the original data used to fit the model
 #'   are used, as extracted by \code{model.frame(object)}. However this will
 #'   currently not work if the model formula contains functions, e.g.
-#'   \code{~ factor(x)}.   The names of the model frame must correspond to
+#'   \code{~ factor(x)}. The names of the model frame must correspond to
 #'   variables in the original data.
 #'
 #' @param type Character vector for the type of predictions desired.
 #'
-#' * \code{"response"} for mean survival (the default)
+#' * \code{"response"} for mean survival time (the default). \code{"mean"} is
+#'   an acceptable synonym
 #'
-#' * \code{"quantile"} for quantiles of the survival distribution specified by
-#'   \code{p}
+#' * \code{"quantile"} for quantiles of the survival distribution as specified
+#'   by \code{p}
 #'
 #' * \code{"rmst"} for restricted mean survival time
 #'
@@ -132,7 +133,7 @@ predict.flexsurvreg <- function(object,
                                           length(conf.level) == 1,
                                           msg = "`conf.level` must be length one and between 0 and 1")
 
-    type <- match.arg(type, c("response", "quantile", "link", "lp", "linear",
+    type <- match.arg(type, c("mean", "response", "quantile", "link", "lp", "linear",
                               "survival", "cumhaz", "hazard", "rmst"))
 
     stype <- switch(
@@ -166,22 +167,40 @@ predict.flexsurvreg <- function(object,
                         (stype %in% c("survival", "cumhaz", "hazard", "rmst") &&
                         length(times) > 1))
 
-    res <- summary(
-      object = object,
-      newdata = newdata,
-      type = stype,
-      quantiles = p,
-      t = times,
-      start = start,
-      ci = conf.int,
-      cl = conf.level,
-      se = se.fit,
-      tidy = TRUE,
-      na.action = na.pass,
-      cross = TRUE
-    )
+    res <- if (stype %in% c("survival", "hazard", "cumhaz", "rmst")) {
+      summary(
+        object = object,
+        newdata = newdata,
+        type = stype,
+        quantiles = p,
+        t = times,
+        start = start,
+        ci = conf.int,
+        cl = conf.level,
+        se = se.fit,
+        tidy = TRUE,
+        na.action = na.pass,
+        cross = TRUE
+      )
+    } else {
+      # Avoid passing `t = times` for non-time based predictions
+      # to avoid noisy warnings
+      summary(
+        object = object,
+        newdata = newdata,
+        type = stype,
+        quantiles = p,
+        start = start,
+        ci = conf.int,
+        cl = conf.level,
+        se = se.fit,
+        tidy = TRUE,
+        na.action = na.pass,
+        cross = TRUE
+      )
+    }
 
-    res <- tidy_rename(res)
+    res <- tidy_rename(res, stype)
 
     if (nest_output) {
       if (stype == 'quantile') {
@@ -207,10 +226,13 @@ tidy_names <- function() {
     )
 }
 
-tidy_rename <- function(x) {
+tidy_rename <- function(x, type) {
   names_tbl <- tidy_names()
   names_to_change <- names_tbl[names_tbl$old %in% names(x), ]
   out <- dplyr::select(x, names_to_change$old)
   colnames(out) <- names_to_change$new
-  tibble::as_tibble(out)
+  out <- tibble::as_tibble(out)
+  if (type == "mean") type <- "time"
+  name_with_type <- rlang::sym(paste0('.pred_', type))
+  dplyr::rename(out, !!name_with_type := .pred)
 }

--- a/R/residuals.flexsurvreg.R
+++ b/R/residuals.flexsurvreg.R
@@ -34,7 +34,7 @@ residuals.flexsurvreg <- function(object, type = "response", ...)
 
   if (type=="response"){ 
   obs_surv <- unname(object$data$Y[, 1])
-  fit_surv <- predict(object, type = type)$.pred
+  fit_surv <- predict(object, type = type)$.pred_time
   res <- obs_surv - fit_surv
   } else if (type=="coxsnell") {
       cx <- coxsnell_flexsurvreg(object)

--- a/man/predict.flexsurvreg.Rd
+++ b/man/predict.flexsurvreg.Rd
@@ -29,14 +29,15 @@ covariate values at which to obtain the fitted predictions.
 If \code{newdata} is omitted, then the original data used to fit the model
 are used, as extracted by \code{model.frame(object)}. However this will
 currently not work if the model formula contains functions, e.g.
-\code{~ factor(x)}.   The names of the model frame must correspond to
+\code{~ factor(x)}. The names of the model frame must correspond to
 variables in the original data.}
 
 \item{type}{Character vector for the type of predictions desired.
 \itemize{
-\item \code{"response"} for mean survival (the default)
-\item \code{"quantile"} for quantiles of the survival distribution specified by
-\code{p}
+\item \code{"response"} for mean survival time (the default). \code{"mean"} is
+an acceptable synonym
+\item \code{"quantile"} for quantiles of the survival distribution as specified
+by \code{p}
 \item \code{"rmst"} for restricted mean survival time
 \item \code{"survival"} for survival probabilities
 \item \code{"cumhaz"} for cumulative hazards

--- a/tests/testthat/test-broom.R
+++ b/tests/testthat/test-broom.R
@@ -1,0 +1,28 @@
+test_that("check tidy", {
+  fitw <- flexsurvreg(Surv(futime, fustat) ~ age,
+                      data = ovarian, dist = "weibull")
+  expect_equal(
+    tidy(fitw, transform = 'baseline.real')$estimate,
+    coef(fitw)
+  )
+})
+
+test_that("check glance", {
+  fitw <- flexsurvreg(Surv(futime, fustat) ~ age,
+                      data = ovarian, dist = "weibull")
+  gl <- glance(fitw)
+  expect_equal(gl$N, fitw$N)
+  expect_equal(gl$events, fitw$events)
+  expect_equal(gl$trisk, fitw$trisk)
+  expect_equal(gl$df, fitw$npars)
+  expect_equal(gl$logLik, fitw$loglik)
+  expect_equal(gl$AIC, fitw$AIC)
+  expect_equal(gl$BIC, BIC(fitw))
+})
+
+test_that("check augment", {
+  fitw <- flexsurvreg(Surv(futime, fustat) ~ age, data = ovarian,
+                      dist = "weibull")
+  expect_equal(augment(fitw)$.pred_time, predict(fitw)$.pred_time)
+  expect_equal(augment(fitw)$.resid, residuals(fitw))
+})

--- a/tests/testthat/test_predict.R
+++ b/tests/testthat/test_predict.R
@@ -5,12 +5,12 @@ test_that('survival predictions', {
   # Single time predictions
   s <- summary(fitw, ovarian, tidy = TRUE, type = 'survival', t = 500)
   p <- predict(fitw, ovarian, type = 'survival', times = 500)
-  expect_equal(s$est, p$.pred)
+  expect_equal(s$est, p$.pred_survival)
 
   # Multiple time predictions
   s <- summary(fitw, ovarian, tidy = TRUE, type = 'survival', t = c(500, 1000))
   p <- predict(fitw, ovarian, type = 'survival', times = c(500, 1000))
-  expect_equal(s$est, tidyr::unnest(p, .pred)$.pred)
+  expect_equal(s$est, tidyr::unnest(p, .pred)$.pred_survival)
 })
 
 test_that('hazard predictions', {
@@ -20,12 +20,12 @@ test_that('hazard predictions', {
   # Single time predictions
   s <- summary(fitw, ovarian, tidy = TRUE, type = 'hazard', t = 500)
   p <- predict(fitw, ovarian, type = 'hazard', times = 500)
-  expect_equal(s$est, p$.pred)
+  expect_equal(s$est, p$.pred_hazard)
 
   # Multiple time predictions
   s <- summary(fitw, ovarian, tidy = TRUE, type = 'hazard', t = c(500, 1000))
   p <- predict(fitw, ovarian, type = 'hazard', times = c(500, 1000))
-  expect_equal(s$est, tidyr::unnest(p, .pred)$.pred)
+  expect_equal(s$est, tidyr::unnest(p, .pred)$.pred_hazard)
 })
 
 test_that('cumhaz predictions', {
@@ -35,12 +35,12 @@ test_that('cumhaz predictions', {
   # Single time predictions
   s <- summary(fitw, ovarian, tidy = TRUE, type = 'cumhaz', t = 500)
   p <- predict(fitw, ovarian, type = 'cumhaz', times = 500)
-  expect_equal(s$est, p$.pred)
+  expect_equal(s$est, p$.pred_cumhaz)
 
   # Multiple time predictions
   s <- summary(fitw, ovarian, tidy = TRUE, type = 'cumhaz', t = c(500, 1000))
   p <- predict(fitw, ovarian, type = 'cumhaz', times = c(500, 1000))
-  expect_equal(s$est, tidyr::unnest(p, .pred)$.pred)
+  expect_equal(s$est, tidyr::unnest(p, .pred)$.pred_cumhaz)
 })
 
 test_that('rmst predictions', {
@@ -50,13 +50,13 @@ test_that('rmst predictions', {
   # Single time predictions
   s <- summary(fitw, ovarian, tidy = TRUE, type = 'rmst', t = 500)
   p <- predict(fitw, ovarian, type = 'rmst', times = 500)
-  expect_equal(s$est, p$.pred)
+  expect_equal(s$est, p$.pred_rmst)
 
   # Multiple time predictions
   s <- summary(fitw, ovarian, tidy = TRUE, type = 'rmst',
                t = c(500, 1000))
   p <- predict(fitw, ovarian, type = 'rmst', times = c(500, 1000))
-  expect_equal(s$est, tidyr::unnest(p, .pred)$.pred)
+  expect_equal(s$est, tidyr::unnest(p, .pred)$.pred_rmst)
 })
 
 test_that('response/mean predictions', {
@@ -64,7 +64,10 @@ test_that('response/mean predictions', {
                       data = ovarian, dist = "weibull")
   s <- summary(fitw, ovarian, tidy = TRUE, type = 'mean')
   p <- predict(fitw, ovarian, type = 'response')
-  expect_equal(s$est, p$.pred)
+  expect_equal(s$est, p$.pred_time)
+
+  p <- predict(fitw, ovarian, type = 'mean')
+  expect_equal(s$est, p$.pred_time)
 })
 
 test_that('quantile predictions', {
@@ -76,13 +79,13 @@ test_that('quantile predictions', {
                quantiles = c(0.5))
   p <- predict(fitw, ovarian, type = 'quantile', times = 500,
                p = c(0.5))
-  expect_equal(s$est, p$.pred)
+  expect_equal(s$est, p$.pred_quantile)
 
   # Multiple quantiles predictions
   s <- summary(fitw, ovarian, tidy = TRUE, type = 'quantile',
                quantile = c(0.1, 0.9))
   p <- predict(fitw, ovarian, type = 'quantile', p = c(0.1, 0.9))
-  expect_equal(s$est, tidyr::unnest(p, .pred)$.pred)
+  expect_equal(s$est, tidyr::unnest(p, .pred)$.pred_quantile)
 })
 
 test_that('link predictions', {
@@ -90,23 +93,48 @@ test_that('link predictions', {
                       data = ovarian, dist = "weibull")
   s <- summary(fitw, ovarian, tidy = TRUE, type = 'link')
   p <- predict(fitw, ovarian, type = 'link')
-  expect_equal(s$est, p$.pred)
+  expect_equal(s$est, p$.pred_link)
 
   p <- predict(fitw, ovarian, type = 'linear')
-  expect_equal(s$est, p$.pred)
+  expect_equal(s$est, p$.pred_link)
 
   p <- predict(fitw, ovarian, type = 'lp')
-  expect_equal(s$est, p$.pred)
+  expect_equal(s$est, p$.pred_link)
 })
 
-test_that('predictions with missing data', {
+test_that('test order (of age) stays the same', {
   fitw <- flexsurvreg(Surv(futime, fustat) ~ age,
                       data = ovarian, dist = "weibull")
+  s <- summary(fitw, newdata = ovarian, type = 'survival', t = 500, tidy = TRUE)
+  expect_equal(ovarian$age, s$age)
+})
+
+test_that('predictions with missing data (gengamma)', {
+  fitw <- flexsurvreg(Surv(futime, fustat) ~ age,
+                      data = ovarian, dist = "gengamma")
   ovarian_miss <- ovarian
   ovarian_miss$age[[5]] <- NA
 
   # Single predictions
-  p <- predict(fitw, newdata = ovarian_miss)
+  p <- predict(fitw, newdata = ovarian_miss, type = 'mean')
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'link')
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'rmst', times = 500)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'quantile', p = 0.5)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'hazard', times = 500)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'cumhaz', times = 500)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'survival', times = 500)
   expect_equal(nrow(p), nrow(ovarian_miss))
 
   # Multiple predictions
@@ -115,9 +143,274 @@ test_that('predictions with missing data', {
   expect_equal(nrow(p), nrow(ovarian_miss))
 })
 
-test_that('test order (of age) stays the same', {
+test_that('predictions with missing data (genf)', {
+  # Use cancer data because genf is non-identifiable with ovarian data
+  fitw <- flexsurvreg(Surv(time, status) ~ age,
+                      data = cancer, dist = "genf")
+  cancer_miss <- cancer
+  cancer_miss$age[[5]] <- NA
+
+  # Single predictions
+  p <- predict(fitw, newdata = cancer_miss, type = 'mean')
+  expect_equal(nrow(p), nrow(cancer_miss))
+
+  p <- predict(fitw, newdata = cancer_miss, type = 'link')
+  expect_equal(nrow(p), nrow(cancer_miss))
+
+  p <- predict(fitw, newdata = cancer_miss, type = 'rmst', times = 500)
+  expect_equal(nrow(p), nrow(cancer_miss))
+
+  p <- predict(fitw, newdata = cancer_miss, type = 'quantile', p = 0.5)
+  expect_equal(nrow(p), nrow(cancer_miss))
+
+  p <- predict(fitw, newdata = cancer_miss, type = 'hazard', times = 500)
+  expect_equal(nrow(p), nrow(cancer_miss))
+
+  p <- predict(fitw, newdata = cancer_miss, type = 'cumhaz', times = 500)
+  expect_equal(nrow(p), nrow(cancer_miss))
+
+  p <- predict(fitw, newdata = cancer_miss, type = 'survival', times = 500)
+  expect_equal(nrow(p), nrow(cancer_miss))
+
+  # Multiple predictions
+  p <- predict(fitw, newdata = cancer_miss,
+               type = 'survival', times = c(500, 1000))
+  expect_equal(nrow(p), nrow(cancer_miss))
+})
+
+test_that('predictions with missing data (weibull)', {
   fitw <- flexsurvreg(Surv(futime, fustat) ~ age,
                       data = ovarian, dist = "weibull")
-  s <- summary(fitw, newdata = ovarian, type = 'survival', t = 500, tidy = TRUE)
-  expect_equal(ovarian$age, s$age)
+  ovarian_miss <- ovarian
+  ovarian_miss$age[[5]] <- NA
+
+  # Single predictions
+  p <- predict(fitw, newdata = ovarian_miss, type = 'mean')
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'link')
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'rmst', times = 500)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'quantile', p = 0.5)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'hazard', times = 500)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'cumhaz', times = 500)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'survival', times = 500)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  # Multiple predictions
+  p <- predict(fitw, newdata = ovarian_miss,
+               type = 'survival', times = c(500, 1000))
+  expect_equal(nrow(p), nrow(ovarian_miss))
+})
+
+test_that('predictions with missing data (gamma)', {
+  fitw <- flexsurvreg(Surv(futime, fustat) ~ age,
+                      data = ovarian, dist = "gamma")
+  ovarian_miss <- ovarian
+  ovarian_miss$age[[5]] <- NA
+
+  # Single predictions
+  p <- predict(fitw, newdata = ovarian_miss, type = 'mean')
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'link')
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'rmst', times = 500)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'quantile', p = 0.5)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'hazard', times = 500)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'cumhaz', times = 500)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'survival', times = 500)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  # Multiple predictions
+  p <- predict(fitw, newdata = ovarian_miss,
+               type = 'survival', times = c(500, 1000))
+  expect_equal(nrow(p), nrow(ovarian_miss))
+})
+
+test_that('predictions with missing data (exponential)', {
+  fitw <- flexsurvreg(Surv(futime, fustat) ~ age,
+                      data = ovarian, dist = "exp")
+  ovarian_miss <- ovarian
+  ovarian_miss$age[[5]] <- NA
+
+  # Single predictions
+  p <- predict(fitw, newdata = ovarian_miss, type = 'mean')
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'link')
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'rmst', times = 500)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'quantile', p = 0.5)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'hazard', times = 500)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'cumhaz', times = 500)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'survival', times = 500)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  # Multiple predictions
+  p <- predict(fitw, newdata = ovarian_miss,
+               type = 'survival', times = c(500, 1000))
+  expect_equal(nrow(p), nrow(ovarian_miss))
+})
+
+test_that('predictions with missing data (llogis)', {
+  fitw <- flexsurvreg(Surv(futime, fustat) ~ age,
+                      data = ovarian, dist = "llogis")
+  ovarian_miss <- ovarian
+  ovarian_miss$age[[5]] <- NA
+
+  # Single predictions
+  p <- predict(fitw, newdata = ovarian_miss, type = 'mean')
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'link')
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'rmst', times = 500)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'quantile', p = 0.5)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'hazard', times = 500)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'cumhaz', times = 500)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'survival', times = 500)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  # Multiple predictions
+  p <- predict(fitw, newdata = ovarian_miss,
+               type = 'survival', times = c(500, 1000))
+  expect_equal(nrow(p), nrow(ovarian_miss))
+})
+
+test_that('predictions with missing data (lnorm)', {
+  fitw <- flexsurvreg(Surv(futime, fustat) ~ age,
+                      data = ovarian, dist = "lnorm")
+  ovarian_miss <- ovarian
+  ovarian_miss$age[[5]] <- NA
+
+  # Single predictions
+  p <- predict(fitw, newdata = ovarian_miss, type = 'mean')
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'link')
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'rmst', times = 500)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'quantile', p = 0.5)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'hazard', times = 500)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'cumhaz', times = 500)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'survival', times = 500)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  # Multiple predictions
+  p <- predict(fitw, newdata = ovarian_miss,
+               type = 'survival', times = c(500, 1000))
+  expect_equal(nrow(p), nrow(ovarian_miss))
+})
+
+test_that('predictions with missing data (gompertz)', {
+  fitw <- flexsurvreg(Surv(futime, fustat) ~ age,
+                      data = ovarian, dist = "gompertz")
+  ovarian_miss <- ovarian
+  ovarian_miss$age[[5]] <- NA
+
+  # Single predictions
+  p <- predict(fitw, newdata = ovarian_miss, type = 'mean')
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'link')
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'rmst', times = 500)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'quantile', p = 0.5)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'hazard', times = 500)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'cumhaz', times = 500)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'survival', times = 500)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  # Multiple predictions
+  p <- predict(fitw, newdata = ovarian_miss,
+               type = 'survival', times = c(500, 1000))
+  expect_equal(nrow(p), nrow(ovarian_miss))
+})
+
+test_that('predictions with missing data (spline)', {
+  fitw <- flexsurvspline(Surv(futime, fustat) ~ age, data = ovarian, k = 3)
+  ovarian_miss <- ovarian
+  ovarian_miss$age[[5]] <- NA
+
+  # Single predictions
+  p <- predict(fitw, newdata = ovarian_miss, type = 'mean')
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'link')
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'rmst', times = 500)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'quantile', p = 0.5)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'hazard', times = 500)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'cumhaz', times = 500)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  p <- predict(fitw, newdata = ovarian_miss, type = 'survival', times = 500)
+  expect_equal(nrow(p), nrow(ovarian_miss))
+
+  # Multiple predictions
+  p <- predict(fitw, newdata = ovarian_miss,
+               type = 'survival', times = c(500, 1000))
+  expect_equal(nrow(p), nrow(ovarian_miss))
 })


### PR DESCRIPTION
Hi @chjackson,

I believe this PR should hopefully get everything back to working/normal for `predict`, `residuals`, and the broom-compatible functions (`tidy`, `glance`, and `augment`), with much expanded test coverage.

I marked this PR as a draft because there still seems to be some issues with handling missing data and I didn't want to mess around with this internal machinery, so I thought I would leave that to you. I will document the issues more clearly in further comments.