### PR TITLE
Enable `.` in formula for `flexsurvreg()`

### DIFF
--- a/man/flexsurvreg.Rd
+++ b/man/flexsurvreg.Rd
@@ -42,6 +42,11 @@ flexsurvreg(
   If there are no covariates, specify \code{1} on the right hand side, for
   example \code{Surv(time, dead) ~ 1}.
 
+  If the right hand side is specified as \code{.} all remaining variables are
+  included as covariates. For example, \code{Surv(time, dead) ~ .}
+  corresponds to \code{Surv(time, dead) ~ age + sex} if \code{data} contains
+  the variables \code{time}, \code{dead}, \code{age}, and \code{sex}.
+
   By default, covariates are placed on the ``location'' parameter of the
   distribution, typically the "scale" or "rate" parameter, through a linear
   model, or a log-linear model if this parameter must be positive.  This

--- a/tests/testthat/test_flexsurvreg.R
+++ b/tests/testthat/test_flexsurvreg.R
@@ -252,6 +252,38 @@ test_that("Covariates on ancillary parameters",{
   }, NA)
 })
 
+test_that("formula can contain dot", {
+  fit_dot <- flexsurvreg(
+    formula = Surv(ovarian$futime, ovarian$fustat) ~ .,
+    data = ovarian,
+    dist = "weibull"
+  )
+  exp_fit <- flexsurvreg(
+    formula = Surv(ovarian$futime, ovarian$fustat) ~ age + resid.ds + rx + ecog.ps,
+    data = ovarian,
+    dist = "weibull"
+  )
+  call_index <- 1
+  expect_equal(fit_dot[-call_index], exp_fit[-call_index])
+
+  fit_dot <- flexsurvreg(
+    formula = Surv(ovarian$futime, ovarian$fustat) ~ .,
+    data = ovarian,
+    anc = list(sigma = ~ age),
+    dist = "gengamma",
+    fixedpars=TRUE
+  )
+  exp_fit <- flexsurvreg(
+    formula = Surv(ovarian$futime, ovarian$fustat) ~ age + resid.ds + rx + ecog.ps,
+    data = ovarian,
+    anc = list(sigma = ~ age),
+    dist = "gengamma",
+    fixedpars=TRUE
+  )
+  call_index <- 1
+  expect_equal(fit_dot[-call_index], exp_fit[-call_index])
+})
+
 test_that("Various errors",{
     expect_error(flexsurvreg(data = ovarian, dist="genf", inits = c(1,2,3)),"\"formula\" is missing")
     expect_error(flexsurvreg(formula="foo", data = ovarian, dist="genf", inits = c(1,2,3)),"\"formula\" must be a formula")


### PR DESCRIPTION
closes #143

I've added to the documentation of the `formula` argument for `flexsurvreg()`. Let me know if you think that this gets the point across.

I've set the default for the new `data` argument to `NULL` so it doesn't change anything for `flexsurvmix()`. I figured that might need some more thinking.

Are there other aspects the tests should cover?

I had the R CMD check fail when I checkout the repo, due to the vignette, but it passes with `devtools::check(vignettes = FALSE)`.  

``` r
library(flexsurv)
#> Loading required package: survival

flexsurvreg(Surv(time, status) ~ ., data = lung, dist = "lognormal")
#> Call:
#> flexsurvreg(formula = Surv(time, status) ~ ., data = lung, dist = "lognormal")
#> 
#> Estimates: 
#>            data mean  est        L95%       U95%       se         exp(est) 
#> meanlog           NA   6.47e+00   3.52e+00   9.41e+00   1.50e+00         NA
#> sdlog             NA   9.97e-01   8.76e-01   1.13e+00   6.57e-02         NA
#> inst        1.07e+01   2.00e-02  -1.37e-03   4.14e-02   1.09e-02   1.02e+00
#> age         6.26e+01  -1.44e-02  -3.43e-02   5.41e-03   1.01e-02   9.86e-01
#> sex         1.38e+00   4.76e-01   1.20e-01   8.32e-01   1.82e-01   1.61e+00
#> ph.ecog     9.58e-01  -5.31e-01  -9.38e-01  -1.25e-01   2.08e-01   5.88e-01
#> ph.karno    8.20e+01  -1.44e-02  -3.74e-02   8.60e-03   1.17e-02   9.86e-01
#> pat.karno   7.96e+01   8.12e-03  -5.00e-03   2.12e-02   6.70e-03   1.01e+00
#> meal.cal    9.29e+02   2.37e-04  -1.66e-04   6.39e-04   2.06e-04   1.00e+00
#> wt.loss     9.72e+00   9.84e-03  -2.61e-03   2.23e-02   6.35e-03   1.01e+00
#>            L95%       U95%     
#> meanlog           NA         NA
#> sdlog             NA         NA
#> inst        9.99e-01   1.04e+00
#> age         9.66e-01   1.01e+00
#> sex         1.13e+00   2.30e+00
#> ph.ecog     3.91e-01   8.83e-01
#> ph.karno    9.63e-01   1.01e+00
#> pat.karno   9.95e-01   1.02e+00
#> meal.cal    1.00e+00   1.00e+00
#> wt.loss     9.97e-01   1.02e+00
#> 
#> N = 167,  Events: 120,  Censored: 47
#> Total time at risk: 51759
#> Log-likelihood = -837.4184, df = 10
#> AIC = 1694.837
```

<sup>Created on 2022-10-13 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>