### PR TITLE
Update to "tidy" format for predictions

### DIFF
--- a/R/predict.flexsurvreg.R
+++ b/R/predict.flexsurvreg.R
@@ -245,7 +245,7 @@ utils::globalVariables('.id')
 tidy_names <- function() {
     tibble::tibble(
         old = c("time", "quantile", "est", "se", "lcl", "ucl"),
-        new = c(".time", ".quantile", ".pred", ".std_error",
+        new = c(".eval_time", ".quantile", ".pred", ".std_error",
                 ".pred_lower", ".pred_upper")
     )
 }


### PR DESCRIPTION
In parsnip and censored, we now refer to the time at which to calculate predicted survival probability (or hazard) as "evaluation time". This is reflected in a change in column name of the output of `predict()`: the column `.time` is now called `.eval_time`. 

We've been using your `predict()` methods basically out of the box because @mattwarkentin made the output fit with tidymodels principals like a glove! Would you consider updating the column name? 

R CMD check fails for me locally with an error in creating a vignette but the tests pass fine.