### PR TITLE
Pass required values to sprintf

### DIFF
--- a/R/mstate.R
+++ b/R/mstate.R
@@ -1275,7 +1275,10 @@ check_trans <- function(trans, flist){
     if (nrow(trans) != ncol(trans)) stop("`trans should be a square matrix")
     ntrans <- length(na.omit(as.vector(trans)))
     if (ntrans != length(flist))
-        stop(sprintf("`trans` has %s numeric entries, but `flist` is of length %s. These should match and equal the number of transitions"))
+        stop(sprintf(
+            "`trans` has %s numeric entries, but `flist` is of length %s. These should match and equal the number of transitions",
+            ntrans, length(flist)
+        ))
 }
 
 

--- a/R/simulate_flexsurvreg.R
+++ b/R/simulate_flexsurvreg.R
@@ -73,8 +73,8 @@ simulate.flexsurvreg <- function(object, nsim=1, seed=NULL,
   if (length(censtime) ==1)
     censtime <- rep(censtime, nd)
   if (length(censtime)!=nd)
-    stop(sprintf("`censtime` of length %s, should be of length %s = nrow(newdata)"),
-         length(censtime), nd)
+    stop(sprintf("`censtime` of length %s, should be of length %s = nrow(newdata)",
+         length(censtime), nd))
   censtime <- rep(censtime, each = nsim)
   event <- as.numeric(time <= censtime)
   time <- ifelse(event, time, censtime)


### PR DESCRIPTION
These `sprintf()` calls currently result in a "too few arguments" error.