### PR TITLE
Add weibullPH to flexsurvreg() and flexsurvtrunc() dist argument helpfile tables

### DIFF
--- a/R/flexsurvreg.R
+++ b/R/flexsurvreg.R
@@ -525,7 +525,8 @@ compress.model.matrices <- function(mml){
 ##'   \tab AFT \cr \code{"gengamma.orig"} \tab Generalized gamma (original) \tab
 ##'   scale \tab AFT \cr \code{"genf"} \tab Generalized F (stable) \tab mu \tab
 ##'   AFT \cr \code{"genf.orig"} \tab Generalized F (original) \tab mu \tab AFT
-##'   \cr \code{"weibull"} \tab Weibull \tab scale \tab AFT \cr \code{"gamma"}
+##'   \cr \code{"weibull"} \tab Weibull \tab scale \tab AFT \cr 
+##'   \code{"weibullPH"} \tab Weibull \tab scale \tab PH \cr \code{"gamma"}
 ##'   \tab Gamma \tab rate \tab AFT \cr \code{"exp"} \tab Exponential \tab rate
 ##'   \tab PH \cr \code{"llogis"} \tab Log-logistic \tab scale \tab AFT \cr
 ##'   \code{"lnorm"} \tab Log-normal \tab meanlog \tab AFT \cr \code{"gompertz"}

--- a/man/flexsurvreg.Rd
+++ b/man/flexsurvreg.Rd
@@ -152,7 +152,8 @@ argument has been used. Default is \code{options()$na.action}.}
   \tab AFT \cr \code{"gengamma.orig"} \tab Generalized gamma (original) \tab
   scale \tab AFT \cr \code{"genf"} \tab Generalized F (stable) \tab mu \tab
   AFT \cr \code{"genf.orig"} \tab Generalized F (original) \tab mu \tab AFT
-  \cr \code{"weibull"} \tab Weibull \tab scale \tab AFT \cr \code{"gamma"}
+  \cr \code{"weibull"} \tab Weibull \tab scale \tab AFT \cr 
+  \code{"weibullPH"} \tab Weibull \tab scale \tab PH \cr \code{"gamma"}
   \tab Gamma \tab rate \tab AFT \cr \code{"exp"} \tab Exponential \tab rate
   \tab PH \cr \code{"llogis"} \tab Log-logistic \tab scale \tab AFT \cr
   \code{"lnorm"} \tab Log-normal \tab meanlog \tab AFT \cr \code{"gompertz"}

--- a/man/flexsurvrtrunc.Rd
+++ b/man/flexsurvrtrunc.Rd
@@ -48,7 +48,8 @@ flexsurvrtrunc(
   \tab AFT \cr \code{"gengamma.orig"} \tab Generalized gamma (original) \tab
   scale \tab AFT \cr \code{"genf"} \tab Generalized F (stable) \tab mu \tab
   AFT \cr \code{"genf.orig"} \tab Generalized F (original) \tab mu \tab AFT
-  \cr \code{"weibull"} \tab Weibull \tab scale \tab AFT \cr \code{"gamma"}
+  \cr \code{"weibull"} \tab Weibull \tab scale \tab AFT \cr 
+  \code{"weibullPH"} \tab Weibull \tab scale \tab PH \cr \code{"gamma"}
   \tab Gamma \tab rate \tab AFT \cr \code{"exp"} \tab Exponential \tab rate
   \tab PH \cr \code{"llogis"} \tab Log-logistic \tab scale \tab AFT \cr
   \code{"lnorm"} \tab Log-normal \tab meanlog \tab AFT \cr \code{"gompertz"}


### PR DESCRIPTION
Thanks for such a great package.

@elliecurnow and myself were teaching an MSc session on parameteric survival models and we noticed that `"weibullPH"` is (I'm guessing accidentally) omitted from the table of information for the `dist` argument in the `flexsurvreg()` and `flexsurvtrunc()` helpfiles. This simply adds that row to those tables.

(PS. I think you forgot to update you pkgdown site after your last release).

cheers
  Tom